### PR TITLE
adding ego toggle to the sip toggle function

### DIFF
--- a/generate.lua
+++ b/generate.lua
@@ -38,7 +38,7 @@ local args = lapp [[
 
 local name    = args.name
 local release = not args.debug
-local version = "1"
+local version = "1s"
 local doall   = args.release
 local own     = args.own
 local defaultaddons = {

--- a/raw-mm.aliases.lua
+++ b/raw-mm.aliases.lua
@@ -7,17 +7,20 @@
 -- work. If not, see <http://creativecommons.org/licenses/by-nc-sa/4.0/>.
 
 function togglesip(what)
-  assert(what == nil or what == "health" or what == "mana", "mm.togglesip wants 'health' or 'mana' as an argument")
+  assert(what == nil or what == "health" or what == "mana" or what == "ego", "mm.togglesip wants 'health', 'mana' or 'ego' as an argument")
 
   local hp = dict.healhealth.sip.aspriority
   local mp = dict.healmana.sip.aspriority
+  local ep = dict.healego.sip.aspriority
   if what == nil or
-    what == "health" and hp < mp or
-    what == "mana" and mp < hp then
-      hp, mp = mp, hp
+    what == "health" and hp < mp and hp < ep or
+    what == "mana" and mp < hp and mp < ep or
+    what == "ego" and ep < hp and ep < mp then
+      hp, mp, ep = ep, hp, mp
   end
   dict.healhealth.sip.aspriority = hp
   dict.healmana.sip.aspriority = mp
+  dict.healego.sip.aspriority = ep
 
   local function getstring(name)
     if name == "healmana_sip" then return "<13,19,180>mana"
@@ -29,7 +32,7 @@ function togglesip(what)
   local prios = {}
   local links = {}
 
-  for _, j in ipairs({dict.healhealth.sip, dict.healmana.sip}) do
+  for _, j in ipairs({dict.healhealth.sip, dict.healmana.sip, dict.healego.sip}) do
     prios[j.name] = j.aspriority
     links[j.name] = j
   end

--- a/raw-mm.aliases.lua
+++ b/raw-mm.aliases.lua
@@ -12,12 +12,41 @@ function togglesip(what)
   local hp = dict.healhealth.sip.aspriority
   local mp = dict.healmana.sip.aspriority
   local ep = dict.healego.sip.aspriority
-  if what == nil or
-    what == "health" and hp < mp and hp < ep or
-    what == "mana" and mp < hp and mp < ep or
-    what == "ego" and ep < hp and ep < mp then
-      hp, mp, ep = ep, hp, mp
+  if what == nil then
+    -- toggles health --> mana --> ego --> health
+    hp, mp, ep = mp, ep, hp
+  else
+    local max, mid, min = 0,0,0
+    for _,v in ipairs({hp,mp,ep}) do
+      if v > max then
+        max,mid,min = v,max,mid
+      elseif v > mid then
+        mid, min = v, mid
+      else
+        min = v
+      end
+    end
+    if what == "health"  then 
+      if mp > ep then
+        hp, mp, ep = max, mid, min
+      else
+        hp, mp, ep = max, min, mid
+      end
+    elseif what == "mana" then
+      if hp > ep then
+        mp, hp, ep = max, mid, min
+      else
+        mp, hp, ep = max, min, mid
+      end
+    elseif what == "ego" then
+      if hp > mp then
+        ep, hp, mp = max, mid, min
+      else
+        ep, hp, mp = max, min, mid
+      end
+    end
   end
+
   dict.healhealth.sip.aspriority = hp
   dict.healmana.sip.aspriority = mp
   dict.healego.sip.aspriority = ep

--- a/raw-mm.aliases.lua
+++ b/raw-mm.aliases.lua
@@ -14,7 +14,7 @@ function togglesip(what)
   local ep = dict.healego.sip.aspriority
   if what == nil then
     -- toggles health --> mana --> ego --> health
-    hp, mp, ep = mp, ep, hp
+    hp, mp, ep = ep, hp, mp
   else
     local max, mid, min = 0,0,0
     for _,v in ipairs({hp,mp,ep}) do


### PR DESCRIPTION
toggle now toggles health -> mana -> ego, or if a vital is specified, puts that in the max prio, and maintains the other two prios in the ascending order they were previously

ie: if the order was health, mana, ego and input toggled mana, it would then be mana, health, ego, and if they input ego next, it would be ego, mana, health
